### PR TITLE
Port loader batch files to shell scripts

### DIFF
--- a/Load.sh
+++ b/Load.sh
@@ -1,10 +1,65 @@
-echo "Hello linux user!"
-echo "this is a backwards compatibilty for linux users."
-echo "WARNING: This is unstable/untested. Some bugs will happen. So be careful." 
+#!/usr/bin/env sh
+
+# Useful resource on whiptail: https://www.redhat.com/sysadmin/use-whiptail
+
+# Configure background title here
+bgTitle="JACOBS NODE.JS CODE EXPLORER v2.0"
+
+# Check for whiptail package
+if [ ! -x "$(command -v whiptail)" ]; then
+  printf "The 'whiptail' command is missing. Please install the package containing whiptail and try again.\n" 
+  exit 1
+fi
 
 
+# Main menu
+response=$(whiptail --cancel-button Exit \
+  --backtitle "$bgTitle" \
+  --title "What would you like to do?" \
+  --menu "" 0 0 0 \
+  1 "Start NPM" \
+  2 Settings \
+3>&1 1>&2 2>&3)
 
-echo "Starting..."
-while [ echo "Starting the bot... Loop mode enabled..." ] do
-sudo node index.js --unhandled-rejections=strict
-Done
+if [ -z "$response" ]; then
+  # Fuck this shit I'm out
+  exit 0
+elif [ "$response" -eq 2 ]; then
+  # Settings (except the script doesn't exist yet because most of the stuff in there doesn't even work on Windows)
+  ./settings.sh
+  exit 0
+fi
+
+# Otherwise, proceed to the NPM menu
+
+# But first prepare the start function
+startBot() {
+  sudo node index.js --unhandled-rejections=strict
+}
+
+response=$(whiptail \
+  --backtitle "$bgTitle" \
+  --title "Enable Loop Mode Or halt when crash?" \
+  --menu "" 0 0 0 \
+  1 "loop mode (recommended)" \
+  2 "Halt when crash" \
+3>&1 1>&2 2>&3)
+
+if [ -z "$response" ]; then
+  # Cancel? How about exit instead
+  exit 0
+elif [ "$response" -eq 1 ]; then
+  # How to exit message
+  whiptail \
+  --backtitle "$bgTitle" \
+  --title "How to exit loop mode" \
+  --msgbox "To exit loop mode, press Ctrl+C, Ctrl+D, or a combination of the two." 0 0
+  
+  # Loop this thing forever
+  while true; do
+    startBot
+  done
+else
+  # Or, you know, just run it once and wait for something to fuck it up
+  startBot
+fi

--- a/Quick load.sh
+++ b/Quick load.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+printf "This is for the startup folder. Loop Mode is enabled by default\n\n"
+
+while true; do
+  sudo node index.js --unhandled-rejections=strict
+done

--- a/cleaner.sh
+++ b/cleaner.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+while true; do
+  inotifywait -qq -e close_write invert.png
+  rm -f invert.png
+done


### PR DESCRIPTION
Adds ports of `Load.bat`, `Quick load.bat`, and `cleaner.bat` to Linux. I could have included a port of `settings.bat`, but seeing as most of the commands there were either Windows-specific or broken, I decided not to. Still, this should be more than enough to close #23.

## Preview
![image](https://user-images.githubusercontent.com/46414358/190878314-88c0ae41-bdbd-459d-871b-483c2f9d1b0b.png)
